### PR TITLE
Feature - set alias on host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # set-alias-on-host
-`set-alias-on-host.sh` is a bash script to set docker network alias on host machine by overwriting 
+`set-alias-on-host.sh` is a shell script to set docker network alias on host machine by overwriting 
 host `/etc/hosts` file. It enables domain name resolved on host machine to point to docker container IP. 
 Intention of `set-alias-on-host.sh` is to help local development without overhead of configuring host DNS subsystem.
 
-Script is **not** intended to be used on production in any way.
+### !!! Script is not intended to be used on production in any way !!!
 
-`set-alias-on-host.sh` implemented in a way to work as a docker-compose entrypoint 
+`set-alias-on-host.sh` implemented in a way it shall work as a docker-compose entrypoint (optional)
+
+Better use however is as a command before actual web server application command.
+So if you run the same service container with some service commands (that doesn't run web server) the 
+script will register IP address of the web server container only
 
 ## Usage
+
+### !!! Create a backup of your hosts file before you let this script to play with it !!!
+
 Script usage
 ```
 set-alias-on-host.sh /path/to/host/machine/etc/hosts/file www.test.domain command-to-start-after
 ```
+
+Dockerfile usage
+```
+ADD https://raw.githubusercontent.com/springload/set-alias-on-host/master/set-alias-on-host.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/set-alias-on-host.sh
+```
+
 docker-compose usage
 ```
 web:
@@ -25,6 +39,8 @@ web:
     volumes:
       - "/etc/hosts:/host/etc/hosts"  # for linux based host
       - "/private/etc/hosts:/host/etc/hosts" # for macOS based host
-    entrypoint: ["set-alias-on-host.sh", "/host/etc/hosts", "www.web.test"]
-    command: ["nginx", "-g", "daemon off;"]  # your app specific
+    # run script first, then your specific web server app
+    command: ["set-alias-on-host.sh", "/host/etc/hosts", "www.web.test", "nginx", "-g", "daemon off;"]
 ```
+
+On MacOs you may need to allow a group write permission for `/private/etc/hosts` file

--- a/README.md
+++ b/README.md
@@ -17,16 +17,20 @@ script will register IP address of the web server container only
 
 Script usage
 ```
-set-alias-on-host.sh /path/to/host/machine/etc/hosts/file www.test.domain command-to-start-after
+set-alias-on-host.sh /path/to/host/machine/etc/hosts/file www.test.domain optimal-command-to-start-after
 ```
 
-Dockerfile usage
+### Docker setup
+
+Add script to your docker image 
+
+Dockerfile example
 ```
 ADD https://raw.githubusercontent.com/springload/set-alias-on-host/master/set-alias-on-host.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/set-alias-on-host.sh
 ```
 
-docker-compose usage
+docker-compose example within the same container as your service
 ```
 web:
     build:
@@ -43,4 +47,10 @@ web:
     command: ["set-alias-on-host.sh", "/host/etc/hosts", "www.web.test", "nginx", "-g", "daemon off;"]
 ```
 
-On MacOs you may need to allow a group write permission for `/private/etc/hosts` file
+> On MacOs you may need to allow a group write permission for `/private/etc/hosts` file
+
+Start your project with `docker-compose up` and you should see message similar to 
+> www.web.test entry added to hosts file
+
+Check your system `hosts` file for new entry for `www.web.test` domain
+Access your service wia `www.web.test` domain in your local browser

--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ web:
     volumes:
       - "/etc/hosts:/host/etc/hosts"  # for linux based host
       - "/private/etc/hosts:/host/etc/hosts" # for macOS based host
-    entrypoint: ["set-route-in-hosts.sh", "/host/etc/hosts", "www.web.test"]
+    entrypoint: ["set-alias-on-host.sh", "/host/etc/hosts", "www.web.test"]
     command: ["nginx", "-g", "daemon off;"]  # your app specific
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # set-alias-on-host
-Pure bash script to set docker network alias on host machine
+`set-alias-on-host.sh` is a bash script to set docker network alias on host machine by overwriting 
+host `/etc/hosts` file. It enables domain name resolved on host machine to point to docker container IP. 
+Intention of `set-alias-on-host.sh` is to help local development without overhead of configuring host DNS subsystem.
+
+Script is **not** intended to be used on production in any way.
+
+`set-alias-on-host.sh` implemented in a way to work as a docker-compose entrypoint 
+
+## Usage
+Script usage
+```
+set-alias-on-host.sh /path/to/host/machine/etc/hosts/file www.test.domain command-to-start-after
+```
+docker-compose usage
+```
+web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    networks:
+      fronend:
+        aliases:
+          - www.web.test  # define alias on docker network
+    volumes:
+      - "/etc/hosts:/host/etc/hosts"  # for linux based host
+      - "/private/etc/hosts:/host/etc/hosts" # for macOS based host
+    entrypoint: ["set-route-in-hosts.sh", "/host/etc/hosts", "www.web.test"]
+    command: ["nginx", "-g", "daemon off;"]  # your app specific
+```

--- a/set-alias-on-host.sh
+++ b/set-alias-on-host.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+HOST_FILE=$1
+HOST_ALIAS=$2
+shift 2  # remove first two script parameters
+TMP_FILE=/tmp/host-hosts
+if [ ! -f "${HOST_FILE}" ] ; then
+    echo "Host \"${HOST_FILE}\" file doesn't exists"
+    exit 2
+fi
+
+if [ -z "${HOST_ALIAS}" ] ; then
+    echo "HOST_ALIAS not set"
+    exit 1
+fi
+
+HOST_ENTRY=$(getent hosts ${HOST_ALIAS} | awk '{ print $1"\t"$2 }') # get alias IP
+if [ -z "${HOST_ENTRY}" ]; then
+    echo "Can't find IP for ${HOST_ALIAS}"
+    exit 3
+fi
+
+# using tmp file and cat > because docker volume mount doesn't allow file replace
+cat ${HOST_FILE} | grep -Fv "${HOST_ALIAS}" > ${TMP_FILE} # remove all lines with host alias
+echo "${HOST_ENTRY}" >> /tmp/hosts  # add new host alias entry to the end of the file
+cat ${TMP_FILE} > ${HOST_FILE};  # replace content of the host hosts file
+rm ${TMP_FILE}
+echo "${HOST_ENTRY} entry added to hosts file"
+
+exec "$@"

--- a/set-alias-on-host.sh
+++ b/set-alias-on-host.sh
@@ -22,7 +22,7 @@ fi
 
 # using tmp file and cat > because docker volume mount doesn't allow file replace
 cat ${HOST_FILE} | grep -Fv "${HOST_ALIAS}" > ${TMP_FILE} # remove all lines with host alias
-echo "${HOST_ENTRY}" >> /tmp/hosts  # add new host alias entry to the end of the file
+echo "${HOST_ENTRY}" >> ${TMP_FILE}  # add new host alias entry to the end of the file
 cat ${TMP_FILE} > ${HOST_FILE};  # replace content of the host hosts file
 rm ${TMP_FILE}
 echo "${HOST_ENTRY} entry added to hosts file"

--- a/set-alias-on-host.sh
+++ b/set-alias-on-host.sh
@@ -27,4 +27,6 @@ cat ${TMP_FILE} > ${HOST_FILE};  # replace content of the host hosts file
 rm ${TMP_FILE}
 echo "${HOST_ENTRY} entry added to hosts file"
 
-exec "$@"
+if [ "$@" != "" ]; then
+    exec "$@"
+fi


### PR DESCRIPTION
A basic shell (not bash) script to tweak local `hosts` file. It works as `sh` script for alpine linux mainly.

It writes and **rewrites** running container IP to the `hosts` file.
* That is potentially dangerous action so backup of your `hosts` file necessary.
